### PR TITLE
Improve download_video

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,7 +49,7 @@ def download_video(id, url):
     :return: name of the video
     """
     video_filename = f"/tmp/video-{id}.mp4"
-    cmd_download = f"youtube-dl --newline -f worst {url} -o {video_filename}"
+    cmd_download = f"youtube-dl --newline -f bestaudio[ext=m4a] {url} -o {video_filename}"
     cmd_name = f"youtube-dl --skip-download --get-title --no-warnings {url}"
     try:
         code = subprocess.run(cmd_download.split())


### PR DESCRIPTION
The PR changes download_video function. Now it downloads only audio. And I'm too lazy to adjust function with ffmpeg :-P

cc https://github.com/alvicsam/ytap-python/issues/8